### PR TITLE
Add Alexis Taillon to authors

### DIFF
--- a/data/authors/alexis_taillon.yml
+++ b/data/authors/alexis_taillon.yml
@@ -1,0 +1,5 @@
+id: alexis_taillon
+name: Alexis Taillon
+linkedin: https://www.linkedin.com/in/alexis-taillon-755b71251/
+github: alexistaillon
+website: https://sites.google.com/view/alexis-taillon-portfolio/

--- a/data/io-events/2024-10-24-octobre-2024-opemin-beta-1.yml
+++ b/data/io-events/2024-10-24-octobre-2024-opemin-beta-1.yml
@@ -7,11 +7,13 @@ talks:
   - authors:
       - joelthebert
     title: 'Le puits sans fond des claviers ergonomiques: comment construire son propre clavier'
+    slides: https://github.com/Pacane/ergo-keyboards/blob/main/keyboard.org
   - authors:
       - ferd
     title: 'Être on-call sans se brûler'
     description: 'Quels sont les facteurs à considérer pour établir des rotations de garde qui sont réalistes et durables.'
   - authors:
       - openmic
+      - alexis_taillon
     title: 'Portion "micro ouvert"'
     description: 'Tout le monde pourra proposer un sujet duquel vous voulez parler de manière improvisée avec pas ou peu de soutien audio-visuel. Les gens voteront, et 1 ou 2 sujets seront retenus (selon le temps) pour des courtes présentations de 3 à 5 minutes.'


### PR DESCRIPTION
This pull request includes updates to author information and event details. The most important changes include adding a new author and updating the details for a specific talk.

Updates to author information:

* [`data/authors/alexis_taillon.yml`](diffhunk://#diff-0f067260dfbc88ebf9bcd4fcb33fc1ce00b89d4c0fe44c8a0d4653bf9208fba6R1-R5): Added a new author, Alexis Taillon, with LinkedIn, GitHub, and website details.

Updates to event details:

* [`data/io-events/2024-10-24-octobre-2024-opemin-beta-1.yml`](diffhunk://#diff-270c6be164fc323068c1a6954ade77dd235f2d2ae30d5e3f295719e8b622b66fR10-R17): Updated the "Le puits sans fond des claviers ergonomiques" talk to include a link to the slides and added Alexis Taillon as an author for the "Portion 'micro ouvert'" talk.