### PR TITLE
Update event dates to 18:00 Montreal Time

### DIFF
--- a/data/io-events/2013-10-29-octobre-2013-aka-beta-1.yml
+++ b/data/io-events/2013-10-29-octobre-2013-aka-beta-1.yml
@@ -1,4 +1,4 @@
-date: '2013-10-29T18:00:00.000Z'
+date: '2013-10-29T23:00:00.000Z'
 location: exode
 talks:
 - authors:

--- a/data/io-events/2013-12-09-dcembre-2013-aka-beta-2.yml
+++ b/data/io-events/2013-12-09-dcembre-2013-aka-beta-2.yml
@@ -1,4 +1,4 @@
-date: '2013-12-09T18:00:00.000Z'
+date: '2013-12-09T23:00:00.000Z'
 eventbrite_id: 9389088015
 location: bar_la_zone_jonquiere
 talks:

--- a/data/io-events/2014-01-13-janvier-2014-nickel-edition.yml
+++ b/data/io-events/2014-01-13-janvier-2014-nickel-edition.yml
@@ -1,4 +1,4 @@
-date: '2014-01-13T18:00:00.000Z'
+date: '2014-01-13T23:00:00.000Z'
 eventbrite_id: 9769359417
 location: exode
 talks:

--- a/data/io-events/2014-02-10-fevrier-2014.yml
+++ b/data/io-events/2014-02-10-fevrier-2014.yml
@@ -1,4 +1,4 @@
-date: '2014-02-10T18:00:00.000Z'
+date: '2014-02-10T23:00:00.000Z'
 eventbrite_id: 10256987927
 location: bar_la_zone_jonquiere
 talks:

--- a/data/io-events/2014-03-10-mars-2014.yml
+++ b/data/io-events/2014-03-10-mars-2014.yml
@@ -1,4 +1,4 @@
-date: '2014-03-10T18:00:00.000Z'
+date: '2014-03-10T23:00:00.000Z'
 eventbrite_id: 10597434211
 location: exode
 talks:

--- a/data/io-events/2014-04-09-avril-2014.yml
+++ b/data/io-events/2014-04-09-avril-2014.yml
@@ -1,4 +1,4 @@
-date: '2014-04-09T18:00:00.000Z'
+date: '2014-04-09T23:00:00.000Z'
 eventbrite_id: 10924929759
 location: bar_la_zone_jonquiere
 talks:

--- a/data/io-events/2014-05-13-mai-2014.yml
+++ b/data/io-events/2014-05-13-mai-2014.yml
@@ -1,4 +1,4 @@
-date: '2014-05-13T18:00:00.000Z'
+date: '2014-05-13T23:00:00.000Z'
 eventbrite_id: 11311337515
 location: exode
 talks:

--- a/data/io-events/2014-06-10-juin-2014.yml
+++ b/data/io-events/2014-06-10-juin-2014.yml
@@ -1,4 +1,4 @@
-date: '2014-06-10T18:00:00.000Z'
+date: '2014-06-10T23:00:00.000Z'
 eventbrite_id: 11717757127
 location: bar_la_zone_jonquiere
 talks:

--- a/data/io-events/2014-09-09-september-2014-de-la-grande-visite-et-des-cadeaux.yml
+++ b/data/io-events/2014-09-09-september-2014-de-la-grande-visite-et-des-cadeaux.yml
@@ -1,4 +1,4 @@
-date: '2014-09-09T18:00:00.000Z'
+date: '2014-09-09T23:00:00.000Z'
 eventbrite_id: 12592567709
 location: exode
 sponsor: Des t-shirts de <a href="http://circleci.com" target="_blank">Circle CI</a>

--- a/data/io-events/2014-10-07-octobre-2014-un-an-dio.yml
+++ b/data/io-events/2014-10-07-octobre-2014-un-an-dio.yml
@@ -1,4 +1,4 @@
-date: '2014-10-07T18:00:00.000Z'
+date: '2014-10-07T23:00:00.000Z'
 eventbrite_id: 13170572537
 location:
 talks:

--- a/data/io-events/2014-11-11-novembre-2014-un-an-dio-pour-vrai.yml
+++ b/data/io-events/2014-11-11-novembre-2014-un-an-dio-pour-vrai.yml
@@ -1,4 +1,4 @@
-date: '2014-11-11T18:00:00.000Z'
+date: '2014-11-11T23:00:00.000Z'
 eventbrite_id: 13746079895
 location: exode
 sponsor: <a href="http://www.demarque.com/travailler-comme-developpeur-chez-demarque/">DeMarque</a>

--- a/data/io-events/2014-12-09-decembre-2014.yml
+++ b/data/io-events/2014-12-09-decembre-2014.yml
@@ -1,4 +1,4 @@
-date: '2014-12-09T18:00:00.000Z'
+date: '2014-12-09T23:00:00.000Z'
 eventbrite_id: 14698544743
 location: tour_a_biere_chicoutimi
 talks:

--- a/data/io-events/2015-01-21-janvier-2015.yml
+++ b/data/io-events/2015-01-21-janvier-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-01-21T18:00:00.000Z'
+date: '2015-01-21T23:00:00.000Z'
 eventbrite_id: 15252480580
 location: exode
 talks:

--- a/data/io-events/2015-02-25-fevrier-2015.yml
+++ b/data/io-events/2015-02-25-fevrier-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-02-25T18:00:00.000Z'
+date: '2015-02-25T23:00:00.000Z'
 eventbrite_id: 15510032926
 location: hopera_jonquiere
   et nourriture!

--- a/data/io-events/2015-03-31-mars-2015.yml
+++ b/data/io-events/2015-03-31-mars-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-03-31T18:00:00.000Z'
+date: '2015-03-31T23:00:00.000Z'
 eventbrite_id: 16327857060
 location: tour_a_biere_chicoutimi
 talks:

--- a/data/io-events/2015-04-28-avril-2015.yml
+++ b/data/io-events/2015-04-28-avril-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-04-28T18:00:00.000Z'
+date: '2015-04-28T23:00:00.000Z'
 eventbrite_id: 16388659923
 location: exode
 talks:

--- a/data/io-events/2015-05-26-mai-2015.yml
+++ b/data/io-events/2015-05-26-mai-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-05-26T18:00:00.000Z'
+date: '2015-05-26T23:00:00.000Z'
 eventbrite_id: 16869582375
 location: entrecote_riverin_jonquiere
 talks:

--- a/data/io-events/2015-07-07-juillet-2015.yml
+++ b/data/io-events/2015-07-07-juillet-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-07-07T18:00:00.000Z'
+date: '2015-07-07T23:00:00.000Z'
 eventbrite_id: 17357823718
 location: microbrasserie_du_lac_st_jean
 talks:

--- a/data/io-events/2015-09-23-septembre-2015.yml
+++ b/data/io-events/2015-09-23-septembre-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-09-23T18:00:00.000Z'
+date: '2015-09-23T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1470133096623433/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2015-10-28-octobre-2015.yml
+++ b/data/io-events/2015-10-28-octobre-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-10-28T18:00:00.000Z'
+date: '2015-10-28T23:00:00.000Z'
 event_url: https://www.facebook.com/events/524316244393655/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2015-12-02-dcembre-2015.yml
+++ b/data/io-events/2015-12-02-dcembre-2015.yml
@@ -1,4 +1,4 @@
-date: '2015-12-02T18:00:00.000Z'
+date: '2015-12-02T23:00:00.000Z'
 event_url: https://www.facebook.com/events/197726173893502/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2016-01-27-janvier-2016.yml
+++ b/data/io-events/2016-01-27-janvier-2016.yml
@@ -1,4 +1,4 @@
-date: '2016-01-27T18:00:00.000Z'
+date: '2016-01-27T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1632742133655739/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2016-03-01-mars-2016.yml
+++ b/data/io-events/2016-03-01-mars-2016.yml
@@ -1,4 +1,4 @@
-date: '2016-03-01T18:00:00.000Z'
+date: '2016-03-01T23:00:00.000Z'
 event_url: https://www.facebook.com/events/189931134704504/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2016-03-30-mars-2016-bienvenue-printemps.yml
+++ b/data/io-events/2016-03-30-mars-2016-bienvenue-printemps.yml
@@ -1,4 +1,4 @@
-date: '2016-03-30T18:00:00.000Z'
+date: '2016-03-30T23:00:00.000Z'
 event_url: https://www.facebook.com/events/810666755732038/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2016-04-27-avril-2016.yml
+++ b/data/io-events/2016-04-27-avril-2016.yml
@@ -1,4 +1,4 @@
-date: '2016-04-27T18:00:00.000Z'
+date: '2016-04-27T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1707690526139089/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2016-06-21-juin-2016.yml
+++ b/data/io-events/2016-06-21-juin-2016.yml
@@ -1,4 +1,4 @@
-date: '2016-06-21T18:00:00.000Z'
+date: '2016-06-21T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1007957892587553/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2016-09-20-septembre-2016.yml
+++ b/data/io-events/2016-09-20-septembre-2016.yml
@@ -1,4 +1,4 @@
-date: '2016-09-20T18:00:00.000Z'
+date: '2016-09-20T23:00:00.000Z'
 event_url: https://www.facebook.com/events/186613181771937/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2016-10-25-octobre-2016.yml
+++ b/data/io-events/2016-10-25-octobre-2016.yml
@@ -1,4 +1,4 @@
-date: '2016-10-25T18:00:00.000Z'
+date: '2016-10-25T23:00:00.000Z'
 event_url: https://www.facebook.com/events/794932377276580/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2016-11-21-novembre-2016-spcial-uqac.yml
+++ b/data/io-events/2016-11-21-novembre-2016-spcial-uqac.yml
@@ -1,4 +1,4 @@
-date: '2016-11-21T18:00:00.000Z'
+date: '2016-11-21T23:00:00.000Z'
 event_url: https://www.facebook.com/events/163206777482547/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2016-12-07-dernier-io-de-2016-alma.yml
+++ b/data/io-events/2016-12-07-dernier-io-de-2016-alma.yml
@@ -1,4 +1,4 @@
-date: '2016-12-07T18:00:00.000Z'
+date: '2016-12-07T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1799450726981595/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2017-01-24-premier-io-de-2017.yml
+++ b/data/io-events/2017-01-24-premier-io-de-2017.yml
@@ -1,4 +1,4 @@
-date: '2017-01-24T18:00:00.000Z'
+date: '2017-01-24T23:00:00.000Z'
 event_url: https://www.facebook.com/events/392164731137634/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2017-02-22-io-de-fvrier-2017.yml
+++ b/data/io-events/2017-02-22-io-de-fvrier-2017.yml
@@ -1,4 +1,4 @@
-date: '2017-02-22T18:00:00.000Z'
+date: '2017-02-22T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1496033413763387/
 location: bistro_du_centre
 talks:

--- a/data/io-events/2017-04-10-io-spcial-fin-de-session-2017-en-collaboration-avec-laemi.yml
+++ b/data/io-events/2017-04-10-io-spcial-fin-de-session-2017-en-collaboration-avec-laemi.yml
@@ -1,4 +1,4 @@
-date: '2017-04-10T18:00:00.000Z'
+date: '2017-04-10T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1119460338187406/
 location: boston_pizza_jonquiere
 talks:

--- a/data/io-events/2017-05-16-lio-de-mai-alma.yml
+++ b/data/io-events/2017-05-16-lio-de-mai-alma.yml
@@ -1,4 +1,4 @@
-date: '2017-05-16T18:00:00.000Z'
+date: '2017-05-16T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1574808475865288/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2017-06-26-io-de-juin-2017.yml
+++ b/data/io-events/2017-06-26-io-de-juin-2017.yml
@@ -1,4 +1,4 @@
-date: '2017-06-26T18:00:00.000Z'
+date: '2017-06-26T23:00:00.000Z'
 event_url: https://www.facebook.com/events/445500365803825
 location: bistro_du_centre
 talks:

--- a/data/io-events/2017-07-27-mta-io-de-juillet-2017.yml
+++ b/data/io-events/2017-07-27-mta-io-de-juillet-2017.yml
@@ -1,4 +1,4 @@
-date: '2017-07-27T18:00:00.000Z'
+date: '2017-07-27T23:00:00.000Z'
 event_url: https://www.facebook.com/events/106670710007633
 location: mikes_chicoutimi_racine
 title: Méta IO de Juillet 2017

--- a/data/io-events/2017-09-19-io-de-septembre-2017.yml
+++ b/data/io-events/2017-09-19-io-de-septembre-2017.yml
@@ -1,4 +1,4 @@
-date: '2017-09-19T18:00:00.000Z'
+date: '2017-09-19T23:00:00.000Z'
 event_url: https://www.facebook.com/events/397532047316656
 location: bistro_du_centre
 talks:

--- a/data/io-events/2017-10-17-io-hacktoberfest-spcial-open-source.yml
+++ b/data/io-events/2017-10-17-io-hacktoberfest-spcial-open-source.yml
@@ -1,4 +1,4 @@
-date: '2017-10-17T18:00:00.000Z'
+date: '2017-10-17T23:00:00.000Z'
 event_url: https://www.facebook.com/events/120214745326424
 location: bistro_du_centre
 talks:

--- a/data/io-events/2017-11-20-io-hardware-luqac.yml
+++ b/data/io-events/2017-11-20-io-hardware-luqac.yml
@@ -1,4 +1,4 @@
-date: '2017-11-20T18:00:00.000Z'
+date: '2017-11-20T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1316410948471000
 location: uqac_aquarium
 talks:

--- a/data/io-events/2017-12-12-dernier-io-de-2017.yml
+++ b/data/io-events/2017-12-12-dernier-io-de-2017.yml
@@ -1,4 +1,4 @@
-date: '2017-12-12T18:00:00.000Z'
+date: '2017-12-12T23:00:00.000Z'
 event_url: https://www.facebook.com/events/2045874012295073
 location: exode
 talks:

--- a/data/io-events/2018-01-16-premier-io-de-2018.yml
+++ b/data/io-events/2018-01-16-premier-io-de-2018.yml
@@ -1,4 +1,4 @@
-date: '2018-01-16T18:00:00.000Z'
+date: '2018-01-16T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1469574146474528
 location: bistro_du_centre
 talks:

--- a/data/io-events/2018-02-20-io-de-fvrier-2018.yml
+++ b/data/io-events/2018-02-20-io-de-fvrier-2018.yml
@@ -1,4 +1,4 @@
-date: '2018-02-20T18:00:00.000Z'
+date: '2018-02-20T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1611677945583993
 location: bistro_du_centre
 talks:

--- a/data/io-events/2018-03-26-io-jeux-vido-luqac.yml
+++ b/data/io-events/2018-03-26-io-jeux-vido-luqac.yml
@@ -1,4 +1,4 @@
-date: '2018-03-26T18:00:00.000Z'
+date: '2018-03-26T23:00:00.000Z'
 event_url: https://www.facebook.com/events/2093498940886079
 location: uqac_aquarium
 talks:

--- a/data/io-events/2018-04-23-de-lio-au-moulin.yml
+++ b/data/io-events/2018-04-23-de-lio-au-moulin.yml
@@ -1,4 +1,4 @@
-date: '2018-04-23T18:00:00.000Z'
+date: '2018-04-23T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1784388525203963
 location: moulin_a_cie
 talks:

--- a/data/io-events/2018-05-14-lio-bleu-dplac-au-pacini.yml
+++ b/data/io-events/2018-05-14-lio-bleu-dplac-au-pacini.yml
@@ -1,4 +1,4 @@
-date: '2018-05-14T18:00:00.000Z'
+date: '2018-05-14T23:00:00.000Z'
 event_url: https://www.facebook.com/events/974324606075464
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2018-06-19-io-de-juin-2018.yml
+++ b/data/io-events/2018-06-19-io-de-juin-2018.yml
@@ -1,4 +1,4 @@
-date: '2018-06-19T18:00:00.000Z'
+date: '2018-06-19T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1012284435563486
 location: bistro_du_centre
 talks:

--- a/data/io-events/2018-09-18-io-de-septembre-2018.yml
+++ b/data/io-events/2018-09-18-io-de-septembre-2018.yml
@@ -1,4 +1,4 @@
-date: '2018-09-18T18:00:00.000Z'
+date: '2018-09-18T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1039568092870432/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2018-10-23-io-hacktoberfest-2018-uqac.yml
+++ b/data/io-events/2018-10-23-io-hacktoberfest-2018-uqac.yml
@@ -1,4 +1,4 @@
-date: '2018-10-23T18:00:00.000Z'
+date: '2018-10-23T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1152923258196040/
 location: uqac_aquarium
 title: IO Hacktoberfest 2018 à UQAC

--- a/data/io-events/2018-12-11-io-novembre-dcembre-2018-alma.yml
+++ b/data/io-events/2018-12-11-io-novembre-dcembre-2018-alma.yml
@@ -1,4 +1,4 @@
-date: '2018-12-11T18:00:00.000Z'
+date: '2018-12-11T23:00:00.000Z'
 event_url: https://www.facebook.com/events/196395121292676/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2019-01-23-io-janvier-2019-chicoutimi-premier-io-de-lanne.yml
+++ b/data/io-events/2019-01-23-io-janvier-2019-chicoutimi-premier-io-de-lanne.yml
@@ -1,4 +1,4 @@
-date: '2019-01-23T18:00:00.000Z'
+date: '2019-01-23T23:00:00.000Z'
 event_url: https://www.facebook.com/events/376737329557674/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2019-02-19-io-fvrier-2019-chicoutimi.yml
+++ b/data/io-events/2019-02-19-io-fvrier-2019-chicoutimi.yml
@@ -1,4 +1,4 @@
-date: '2019-02-19T18:00:00.000Z'
+date: '2019-02-19T23:00:00.000Z'
 event_url: https://www.facebook.com/events/387219898762930/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2019-03-19-io-mars-2019-chicoutimi.yml
+++ b/data/io-events/2019-03-19-io-mars-2019-chicoutimi.yml
@@ -1,4 +1,4 @@
-date: '2019-03-19T18:00:00.000Z'
+date: '2019-03-19T23:00:00.000Z'
 event_url: https://www.facebook.com/events/302634487076300/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2019-04-11-io-jeux-vido-luqac-20.yml
+++ b/data/io-events/2019-04-11-io-jeux-vido-luqac-20.yml
@@ -1,4 +1,4 @@
-date: '2019-04-11T18:00:00.000Z'
+date: '2019-04-11T23:00:00.000Z'
 event_url: https://www.facebook.com/events/2411719792172173/
 location: uqac_aquarium
 talks:

--- a/data/io-events/2019-05-28-io-de-mai-chez-conformit.yml
+++ b/data/io-events/2019-05-28-io-de-mai-chez-conformit.yml
@@ -1,4 +1,4 @@
-date: '2019-05-28T18:00:00.000Z'
+date: '2019-05-28T23:00:00.000Z'
 event_url: https://www.facebook.com/events/2270068819933982/
 location: conformit
 talks:

--- a/data/io-events/2019-06-26-io-juin-2019-resilience-engineering-et-smesc.yml
+++ b/data/io-events/2019-06-26-io-juin-2019-resilience-engineering-et-smesc.yml
@@ -1,4 +1,4 @@
-date: '2019-06-26T18:00:00.000Z'
+date: '2019-06-26T23:00:00.000Z'
 event_url: https://www.facebook.com/events/2275533349166633/
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2019-07-16-saglac-io-party-dt-2019.yml
+++ b/data/io-events/2019-07-16-saglac-io-party-dt-2019.yml
@@ -1,4 +1,4 @@
-date: '2019-07-16T18:00:00.000Z'
+date: '2019-07-16T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1245692662274516/
 location: tlm_chicoutimi
 title: Saglac IO - Party d'été 2019

--- a/data/io-events/2019-09-19-io-septembre-2019-chez-stas.yml
+++ b/data/io-events/2019-09-19-io-septembre-2019-chez-stas.yml
@@ -1,4 +1,4 @@
-date: '2019-09-19T18:00:00.000Z'
+date: '2019-09-19T23:00:00.000Z'
 event_url: https://www.facebook.com/events/624576501386603/
 location: stas_chicoutimi
 talks:

--- a/data/io-events/2019-11-20-io-novembre-2019-alma.yml
+++ b/data/io-events/2019-11-20-io-novembre-2019-alma.yml
@@ -1,4 +1,4 @@
-date: '2019-11-20T18:00:00.000Z'
+date: '2019-11-20T23:00:00.000Z'
 event_url: https://www.facebook.com/events/394900991193067/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2019-12-17-mta-saglac-io-2019.yml
+++ b/data/io-events/2019-12-17-mta-saglac-io-2019.yml
@@ -1,4 +1,4 @@
-date: '2019-12-17T18:00:00.000Z'
+date: '2019-12-17T23:00:00.000Z'
 event_url: https://www.facebook.com/events/437558496915185/
 location: boston_pizza_jonquiere
 title: Méta Saglac IO - 2019

--- a/data/io-events/2019-12-28-io-2020-test.yml
+++ b/data/io-events/2019-12-28-io-2020-test.yml
@@ -1,7 +1,7 @@
 # TODO: remove this file?
 title: IO 2020 test
 description: Le Saglac IO est de retour en personne à Chicoutimi, au restaurant Mikes.
-date: '2020-01-13T23:00:26.372Z'
+date: '2020-01-13T23:00:00.000Z'
 event_url: facebook link here test
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2020-01-13-premier-io-2020-chez-devicom.yml
+++ b/data/io-events/2020-01-13-premier-io-2020-chez-devicom.yml
@@ -1,4 +1,4 @@
-date: '2020-01-13T18:00:00.000Z'
+date: '2020-01-13T23:00:00.000Z'
 event_url: https://www.facebook.com/events/858331021252495/
 location: devicom_chicoutimi
 talks:

--- a/data/io-events/2020-02-26-io-de-fvrier-2020-chez-conformit.yml
+++ b/data/io-events/2020-02-26-io-de-fvrier-2020-chez-conformit.yml
@@ -1,4 +1,4 @@
-date: '2020-02-26T18:00:00.000Z'
+date: '2020-02-26T23:00:00.000Z'
 event_url: https://www.facebook.com/events/2794092540637355/
 location: conformit
 talks:

--- a/data/io-events/2021-01-13-janvier-2021-en-ligne.yml
+++ b/data/io-events/2021-01-13-janvier-2021-en-ligne.yml
@@ -1,4 +1,4 @@
-date: '2021-01-13T18:00:00.000Z'
+date: '2021-01-13T23:00:00.000Z'
 event_url: https://www.airmeet.com/e/9079c3e0-51bd-11eb-8497-5553e7235276
 location: online
 talks:

--- a/data/io-events/2021-03-23-io-de-mars-2021-en-virtuel.yml
+++ b/data/io-events/2021-03-23-io-de-mars-2021-en-virtuel.yml
@@ -1,4 +1,4 @@
-date: '2021-03-23T18:00:00.000Z'
+date: '2021-03-23T23:00:00.000Z'
 event_url: https://www.airmeet.com/e/87444d10-7d53-11eb-bcad-59162d08a0eb
 location: online
 talks:

--- a/data/io-events/2021-04-27-io-davril-2021-en-virtuel.yml
+++ b/data/io-events/2021-04-27-io-davril-2021-en-virtuel.yml
@@ -1,4 +1,4 @@
-date: '2021-04-27T18:00:00.000Z'
+date: '2021-04-27T23:00:00.000Z'
 event_url: https://www.airmeet.com/event/aab37ec0-a075-11eb-bb44-d52cffa4c0b3
 location: online
 talks:

--- a/data/io-events/2021-10-21-io-doctobre-2021-retour-en-personne.yml
+++ b/data/io-events/2021-10-21-io-doctobre-2021-retour-en-personne.yml
@@ -1,4 +1,4 @@
-date: '2021-10-21T18:00:00.000Z'
+date: '2021-10-21T23:00:00.000Z'
 event_url: https://www.facebook.com/events/388684586055492/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2022-03-24-io-2022-en-personne-2.yml
+++ b/data/io-events/2022-03-24-io-2022-en-personne-2.yml
@@ -1,6 +1,6 @@
 title: Premier IO 2022 - Retour en personne 2!
 description: Le Saglac IO est de retour en personne à Chicoutimi, au restaurant Mikes. On se donne rendez-vous à 18h, et les conférences commencent vers 19h00!
-date: '2022-03-24T18:00:00.000Z'
+date: '2022-03-24T23:00:00.000Z'
 event_url: https://www.facebook.com/events/917008115661764
 location: mikes_chicoutimi_racine
 talks:

--- a/data/io-events/2022-03-24-io-davril-2022-au-lion-bleu.yml
+++ b/data/io-events/2022-03-24-io-davril-2022-au-lion-bleu.yml
@@ -1,4 +1,4 @@
-date: '2022-03-24T18:00:00.000Z'
+date: '2022-03-24T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1221379294933684/
 location: lion_bleu
 talks:

--- a/data/io-events/2022-11-15-io-de-novembre-chez-pulsar-informatique copy.yml
+++ b/data/io-events/2022-11-15-io-de-novembre-chez-pulsar-informatique copy.yml
@@ -1,6 +1,6 @@
 title: IO de novembre chez Pulsar Informatique
 description: Nous vous invitons à vous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:00.
-date: '2022-11-15T18:00:00.000Z'
+date: '2022-11-15T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1292315631348928/
 location: pulsar_informatique
 talks:

--- a/data/io-events/2022-11-15-io-de-novembre-chez-pulsar-informatique.yml
+++ b/data/io-events/2022-11-15-io-de-novembre-chez-pulsar-informatique.yml
@@ -1,4 +1,4 @@
-date: '2022-11-15T18:00:00.000Z'
+date: '2022-11-15T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1292315631348928/
 location: pulsar_informatique.yml
 talks:

--- a/data/io-events/2022-12-14-io-dcembre-2022-alma.yml
+++ b/data/io-events/2022-12-14-io-dcembre-2022-alma.yml
@@ -1,4 +1,4 @@
-date: '2022-12-14T18:00:00.000Z'
+date: '2022-12-14T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1533854587129087
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2022-12-14-io-decembre-2022-alma.yml
+++ b/data/io-events/2022-12-14-io-decembre-2022-alma.yml
@@ -1,6 +1,6 @@
 title: IO décembre 2022 à Alma!
 description: Nous vous invitons à vous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:00. Venez jaser techno pour la dernière de 2022 avec nous! 🙂
-date: 2022-12-14T18:00:00.000Z
+date: 2022-12-14T23:00:00.000Z
 event_url: https://www.facebook.com/events/1533854587129087/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2023-02-21-io-fevrier-2023-a-luqac.yml
+++ b/data/io-events/2023-02-21-io-fevrier-2023-a-luqac.yml
@@ -1,6 +1,6 @@
 title: IO février 2023 à l'UQAC
 description: Nous vous invitons à vous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:30. Venez jaser techno pour bien débuter l'année avec la communauté du Saglac IO et de l'AEMI! 🙂
-date: '2023-02-21T18:00:00.000Z'
+date: '2023-02-21T23:00:00.000Z'
 event_url: https://www.facebook.com/events/1637235870074913/
 location: uqac_aquarium
 talks:

--- a/data/io-events/2023-06-07-io-juin-2023-a-alma.yml
+++ b/data/io-events/2023-06-07-io-juin-2023-a-alma.yml
@@ -1,6 +1,6 @@
 title: IO juin 2023 à Alma!
 description: Nous vous invitons à vous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:00. Venez jaser techno avec nous! 🙂
-date: '2023-06-07T18:00:00.000Z'
+date: '2023-06-07T23:00:00.000Z'
 event_url: https://www.facebook.com/events/270127805447346
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2023-10-25-octobre-2023-chez-ubi.yml
+++ b/data/io-events/2023-10-25-octobre-2023-chez-ubi.yml
@@ -1,6 +1,6 @@
 title: "IO d'octobre 2023 chez Ubisoft (10 ans d'IO!)"
 description: 'Nous vous invitons à vous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:00. Venez jaser techno avec nous! 🙂'
-date: '2023-10-25T18:00:00.000Z'
+date: '2023-10-25T23:00:00.000Z'
 event_url: https://www.facebook.com/events/241778011860741/
 location: ubisoft_saguenay
 talks:

--- a/data/io-events/2024-06-05-juin-2024.yml
+++ b/data/io-events/2024-06-05-juin-2024.yml
@@ -1,6 +1,6 @@
 title: 'Juin 2024 au Café du Clocher'
 description: 'Nous vous invitons à nous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:00. Venez jaser techno avec nous! 🙂'
-date: '2024-06-05T18:00:00.000Z'
+date: '2024-06-05T23:00:00.000Z'
 event_url: https://www.facebook.com/events/420311680852600/
 location: cafe_du_clocher_alma
 talks:

--- a/data/io-events/2024-10-24-octobre-2024-opemin-beta-1.yml
+++ b/data/io-events/2024-10-24-octobre-2024-opemin-beta-1.yml
@@ -1,6 +1,6 @@
 title: '"micro ouvert" beta 1 + doublé des frêres Trottier-Hebert'
 description: 'Nous vous invitons à nous joindre pour manger et/ou prendre un verre en discutant de techno et de développement informatique. On se donne rendez-vous à 18:00, et les présentations commencent vers 19:00. Venez jaser techno avec nous! 🙂'
-date: '2024-10-24T18:00:00.000Z'
+date: '2024-10-24T23:00:00.000Z'
 event_url: https://www.facebook.com/events/853584520233971/
 location: scores_chicoutimi
 talks:


### PR DESCRIPTION
On wé to Québec Icitte

This pull request updates the event times for several event files in the `data/io-events` directory. The changes involve modifying the event start times from 18:00 to 23:00.

Time updates for events:

* Updated event time in `data/io-events/2013-10-29-octobre-2013-aka-beta-1.yml` from 18:00 to 23:00.
* Updated event time in `data/io-events/2013-12-09-dcembre-2013-aka-beta-2.yml` from 18:00 to 23:00.
* Updated event time in `data/io-events/2014-01-13-janvier-2014-nickel-edition.yml` from 18:00 to 23:00.
* Updated event time in `data/io-events/2014-02-10-fevrier-2014.yml` from 18:00 to 23:00.
* Updated event time in `data/io-events/2014-03-10-mars-2014.yml` from 18:00 to 23:00.
* etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated event dates for multiple events to reflect a new scheduled time (from 18:00 to 23:00 UTC).
- **Bug Fixes**
	- Corrected date formatting for various events to ensure consistency.
- **Documentation**
	- No structural changes to event details, including titles, descriptions, and talks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->