### PR TITLE
Add event "Jeudi à Jonquière: Feature Flags et Neovim" with details

### DIFF
--- a/data/io-events/2025-04-17-jeudi-jonquiere-feature-flags-et-neovim.yml
+++ b/data/io-events/2025-04-17-jeudi-jonquiere-feature-flags-et-neovim.yml
@@ -1,0 +1,27 @@
+title: 'Jeudi à Jonquière: Feature Flags et Neovim au SaglacIO'
+description: |
+  On se retrouve ce jeudi au Boston Pizza de Jonquière à 18h00 pour une nouvelle soirée techno qui s'annonce captivante !
+
+  Au programme:
+
+  - **Talk** : "Feature Flags: Petit Manuel de Survie" par Benjamin Destrempes
+  - **Lightning talk**: "Neovim" par Jean-Michel Plourde
+  - **Micro ouvert**: Venez proposer vos sujets pour des présentations courtes! Des idées, des découvertes récentes, une techno que vous adorez? C'est le moment de partager !
+
+  Le micro ouvert est une excellente occasion de partager vos passions, technos ou anecdotes avec la communauté, peu importe votre niveau d'expérience. Pas besoin de slides sophistiqués, juste votre enthousiasme !
+date: '2025-04-17T18:00:00.000Z'
+event_url: https://www.facebook.com/share/1C3Z5Sp1HN/
+location: boston_pizza_jonquiere
+talks:
+  - authors:
+      - benjamin_destrempes
+    title: 'Feature Flags: Petit Manuel de Survie'
+    description: 'Un talk sur les Feature Flags et leur utilisation en développement logiciel.'
+  - authors:
+      - jim_plourde
+    title: 'Neovim'
+    description: "Un lightning talk sur Neovim, l'éditeur de texte moderne basé sur Vim."
+  - authors:
+      - openmic
+    title: 'Portion "micro ouvert"'
+    description: 'Tout le monde pourra proposer un sujet duquel vous voulez parler de manière improvisée avec pas ou peu de soutien audio-visuel. Les gens voteront, et 1 ou 2 sujets seront retenus pour des courtes présentations de 3 à 5 minutes.'

--- a/data/io-events/2025-04-17-jeudi-jonquiere-feature-flags-et-neovim.yml
+++ b/data/io-events/2025-04-17-jeudi-jonquiere-feature-flags-et-neovim.yml
@@ -24,4 +24,4 @@ talks:
   - authors:
       - openmic
     title: 'Portion "micro ouvert"'
-    description: 'Tout le monde pourra proposer un sujet duquel vous voulez parler de manière improvisée avec pas ou peu de soutien audio-visuel. Les gens voteront, et 1 ou 2 sujets seront retenus pour des courtes présentations de 3 à 5 minutes.'
+    description: 'Tout le monde pourra proposer un sujet duquel vous voulez parler de manière improvisée avec pas ou peu de soutien audio-visuel. Les gens voteront (ou pas), et 1 ou 2 sujets seront retenus pour des courtes présentations de 3 à 5 minutes.'


### PR DESCRIPTION
This pull request adds a new event entry to the `data/io-events` directory for an upcoming technology meetup. The event includes talks on Feature Flags and Neovim, as well as an open mic session for community participation.

### New Event Details:

* **Event Title and Description**: Added a new event titled "Jeudi à Jonquière: Feature Flags et Neovim au SaglacIO," scheduled for April 17, 2025, at 6:00 PM at Boston Pizza in Jonquière. The description highlights the event's agenda, including a talk on Feature Flags, a lightning talk on Neovim, and an open mic session.

* **Talks and Speakers**:
  - **Feature Flags Talk**: Presented by Benjamin Destrempes, covering the use of Feature Flags in software development.
  - **Neovim Lightning Talk**: Delivered by Jean-Michel Plourde, focusing on the modern text editor Neovim.
  - **Open Mic Session**: An interactive segment where attendees can propose and vote on topics for short presentations.

* **Event Metadata**: Includes event date, URL, and location details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new event scheduled for April 17, 2025, in Jonquière, featuring a main talk on feature flags, a lightning talk on Neovim, and an open mic segment for attendee presentations. Event details and participation information are now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->